### PR TITLE
Use es5-shim for IE compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Starter Application for React, CommonJS, JSX, Server Rendering.",
   "main": "index.js",
   "dependencies": {
+    "es5-shim": "~2.1.0",
     "React": "git://github.com/facebook/react.git",
     "optimist": "0.6.0",
     "react-page-middleware": "git://github.com/facebook/react-page-middleware.git",

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@
  * @jsx React.DOM
  */
 
+require('es5-shim/es5-sham');
+
 var Banner = require('./elements/Banner/Banner.js');
 var React = require('React');
 var SiteBoilerPlate = require('./core/SiteBoilerPlate.js');


### PR DESCRIPTION
By default, we should support IE8. This is optional though and can be removed from any local project.
