### PR TITLE
Add a utility "SiteStyles" that manage site-wide styles

### DIFF
--- a/src/core/SiteBoilerPlate.js
+++ b/src/core/SiteBoilerPlate.js
@@ -17,6 +17,7 @@
  */
 
 var React = require('React');
+var SiteStyles = require('SiteStyles');
 
 /**
  * We should support/experiment with modelling css dependencies using the exact
@@ -31,10 +32,11 @@ var React = require('React');
  *    // Depends on css from dependency 'bootstrap' in package.json
  *    require('bootstrap/Text-Input.css');
  *
- * For now, you have to (one by one) make sure the index.js page includes the
- * css file your project depends on directly. Even in that case, we'll use
- * commonJS resolution for css files as well, so that if you whitelist things in
- * node_modules for inclusion in your bundle, the resources in those will be
+ * For now, you have to use {SiteStyles} to make sure the index.js page
+ * includes the styles your project depends on directly. Even in that case,
+ * we'll use commonJS resolution for css files as well, so that if you
+ * whitelist things in node_modules for inclusion in your bundle, the
+ * resources in those will be
  * accessible as well.
  */
 
@@ -59,7 +61,18 @@ var React = require('React');
  * });
  */
 
+SiteStyles.addLink('/core/SiteBoilerPlate.css');
+
 var SiteBoilerPlate = React.createClass({
+
+  componentDidMount: function() {
+    SiteStyles.onChange = this.forceUpdate;
+  },
+
+  componentWillUnmount: function() {
+    SiteStyles.onChange = null;
+  },
+
   render: function() {
     return (
       <html>
@@ -69,8 +82,8 @@ var SiteBoilerPlate = React.createClass({
             name="viewport"
             content="width=device-width, initial-scale=1.0, user-scalable=no"
           />
-          <link rel="stylesheet" href="/core/SiteBoilerPlate.css" />
-          <link rel="stylesheet" href="/elements/Banner/Banner.css" />
+
+          {SiteStyles.renderToComponents()}
         </head>
         <body>
           {this.props.children}

--- a/src/core/SiteBoilerPlate.js
+++ b/src/core/SiteBoilerPlate.js
@@ -63,6 +63,32 @@ var SiteStyles = require('SiteStyles');
 
 SiteStyles.addLink('/core/SiteBoilerPlate.css');
 
+var SiteBoilerPlateHead = React.createClass({
+  componentDidMount: function() {
+    SiteStyles.onChange = this.forceUpdate;
+    debugger;
+  },
+
+  componentWillUnmount: function() {
+    SiteStyles.onChange = null;
+  },
+
+  render: function() {
+    return (
+      <head>
+        <title>React Page | Client-Server JavaScript Rendering</title>
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1.0, user-scalable=no"
+        />
+
+        {SiteStyles.renderToComponents()}
+      </head>
+    );
+  }
+});
+
+
 var SiteBoilerPlate = React.createClass({
 
   componentDidMount: function() {
@@ -76,15 +102,7 @@ var SiteBoilerPlate = React.createClass({
   render: function() {
     return (
       <html>
-        <head>
-          <title>React Page | Client-Server JavaScript Rendering</title>
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1.0, user-scalable=no"
-          />
-
-          {SiteStyles.renderToComponents()}
-        </head>
+        <SiteBoilerPlateHead />
         <body>
           {this.props.children}
         </body>

--- a/src/core/SiteStyles.js
+++ b/src/core/SiteStyles.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @providesModule SiteStyles
+ * @jsx React.DOM
+ */
+"use strict";
+
+var React = require('React');
+
+/**
+ * Utility to manage site-wide styles.
+ */
+var SiteStyles = {
+  /**
+   * @type {array}
+   */
+  _rules: [],
+
+  /**
+   * @param {object} newRules
+   */
+  addRules: function(newRules) {
+    var rules = SiteStyles._rules;
+    for (var selector in newRules) {
+      var ruleText =  selector + '{';
+      var declarations = newRules[selector];
+      for (var property in declarations) {
+        ruleText += property + ':' + declarations[property] + ';';
+      }
+      ruleText += '}';
+      rules.push(ruleText);
+    }
+    SiteStyles._onChange();
+  },
+
+  /**
+   * Use the CSS @import() rule to include styles to the site.
+   * Note that using @import() may block the parallel downloading of CSS files.
+   * See http://www.stevesouders.com/blog/2009/04/09/dont-use-import/
+   * @param {url} url
+   */
+  addImport: function(url) {
+    SiteStyles._rules.push({
+      importText: '@import("' + url + '"")'
+    });
+    SiteStyles._onChange();
+  },
+
+  /**
+   * Add a stylesheet <link rel="stylesheet" href="a.css" />
+   * to the site. Note that In Internet Explorer 8 and 9, only 31 stylesheets
+   * at most can be inserted into the document. If you plan to load many
+   * stylesheets in the page, do consider using a better CSS package system that
+   * shall automatically package many CSS files into fewer files or just use
+   * {SiteStyles#addRules} and {SiteStyles#addImport} to load more styles.
+   * @param {url} url
+   */
+  addLink: function(url) {
+    SiteStyles._rules.push({
+      linkURL: url
+    });
+    SiteStyles._onChange();
+  },
+
+  /**
+   * @return {array<SiteStyle>}
+   */
+  renderToComponents: function() {
+    var rules = SiteStyles._rules;
+    var components = [];
+    var cssText = '';
+    var rulesCount = 0;
+    var importsCount = 0;
+    var index = 0;
+
+    for (var i = 0, j = rules.length; i < j; i++) {
+      var rule = rules[i];
+      if (rule.linkURL) {
+        if (cssText) {
+          components.push(
+            <style
+              key={'SiteStyle' + (index++)}
+              dangerouslySetInnerHTML={{__html: cssText}}
+            />
+          );
+          rulesCount = 0;
+          cssText = '';
+          importsCount = 0;
+        }
+
+        components.push(
+          <link
+            key={'SiteStyle' + (index++)}
+            rel="stylesheet"
+            href={rule.linkURL}
+          />
+        );
+        continue;
+      }
+
+      cssText += rule;
+      rulesCount++;
+
+      if (rule.importText) {
+        importsCount++;
+      }
+
+      if (rulesCount > 4095 || importsCount > 31) {
+        // Stylesheet has limits in Internet Explorer 8 and 9 so we need to
+        // shard style rules into several stylesheets.
+        // 1. A sheet may contain up to 4095 rules.
+        // 2. A sheet may @import up to 31 sheets
+        // See http://bit.ly/mARqBv
+        components.push(
+          <style
+            key={'SiteStyle' + (index++)}
+            dangerouslySetInnerHTML={{__html: cssText}}
+          />
+        );
+        rulesCount = 0;
+        cssText = '';
+        importsCount = 0;
+      }
+    }
+
+    if (cssText) {
+      components.push(
+        <style
+          key={'SiteStyle' + (index++)}
+          dangerouslySetInnerHTML={{__html: cssText}}
+        />
+      );
+    }
+    return components
+  },
+
+  _onChange: function() {
+    SiteStyles.onChange && SiteStyles.onChange();
+  }
+};
+
+module.exports = SiteStyles;

--- a/src/elements/Banner/Banner.js
+++ b/src/elements/Banner/Banner.js
@@ -17,7 +17,9 @@
  */
 "use strict";
 
+var BannerCSSRules = require('./BannerCSSRules');
 var React = require('React');
+var SiteStyles = require('SiteStyles');
 
 /**
  * We should support/experiment with modelling css dependencies using the exact
@@ -32,12 +34,15 @@ var React = require('React');
  *    // Depends on css from dependency 'bootstrap' in package.json
  *    require('bootstrap/Text-Input.css');
  *
- * For now, you have to (one by one) make sure the index.js page includes the
- * css file your project depends on directly. Even in that case, we'll use
- * commonJS resolution for css files as well, so that if you whitelist things in
- * node_modules for inclusion in your bundle, the resources in those will be
+ * For now, you have to use {SiteStyles} to make sure the index.js page
+ * includes the styles your project depends on directly. Even in that case,
+ * we'll use commonJS resolution for css files as well, so that if you
+ * whitelist things in node_modules for inclusion in your bundle, the
+ * resources in those will be
  * accessible as well.
  */
+
+ SiteStyles.addRules(BannerCSSRules);
 
 /**
  * Look at Banner, Michael!
@@ -46,9 +51,13 @@ var Banner = React.createClass({
   getInitialState: function() {
     return {initialized: false};
   },
+
   componentDidMount: function() {
-    this.setState({initialized: true});
+    this.setState({
+      initialized: true
+    });
   },
+
   render: function() {
     var classes =
       'banner ' + (this.state.initialized ? 'fadeIn' : '');

--- a/src/elements/Banner/BannerCSSRules.js
+++ b/src/elements/Banner/BannerCSSRules.js
@@ -14,21 +14,24 @@
  * limitations under the License.
  */
 
-h1.banner {
-  opacity: 0;
-  font-family: "Helvetica";
-  color: #444;
-  font-weight: bold;
-  margin-top: 60px;
-  margin-bottom: 0px;
-  text-align: center;
-  -webkit-user-select: none;
-  font-size: 5vh; /* Chrome bug prevents resizing on window resize! */
-  width: 100%;    /* Putting width 100% causes repaint on resize */
-}
+var BannerCSSRules = {
+  'h1.banner': {
+    '-webkit-user-select': 'none',
+    'color': '#444',
+    'font-family': 'Helvetica',
+    'font-size': '5vh',  // Chrome bug prevents resizing on window resize!
+    'font-weight': 'bold',
+    'margin-bottom': 0,
+    'margin-top': '60px',
+    'opacity': 0,
+    'text-align': 'center',
+    'width': '100%' // Putting width 100% causes repaint on resize
+  },
 
-h1.banner.fadeIn {
-  opacity: 1;
-  transition: opacity 3s ease-in;
-}
+  'h1.banner.fadeIn': {
+    'opacity': 1,
+    'transition': 'opacity 3s ease-in'
+  }
+};
 
+module.exports = BannerCSSRules;


### PR DESCRIPTION
For now, developer is forced to put the links of his own component's CSS files inside <SiteBoilerPlate /> and that approach does not seem scalable.

I created a simple utility "SiteStyles" that allows developer to register component's styles at individual component level programmatically.
