### PR TITLE
Add missing StyleRules modules

### DIFF
--- a/src/core/SiteBoilerPlate.js
+++ b/src/core/SiteBoilerPlate.js
@@ -19,7 +19,7 @@
 var React = require('React');
 var ReactStyle = require('ReactStyle');
 var ReactStyleHead = require('ReactStyleHead');
-var SiteBoilerPlateStyleRules = require('SiteBoilerPlateStyleRules');
+var SiteBoilerPlateStyleRules = require('./SiteBoilerPlateStyleRules.js');
 
 /**
  * We should support/experiment with modelling css dependencies using the exact

--- a/src/core/SiteBoilerPlateStyleRules.js
+++ b/src/core/SiteBoilerPlateStyleRules.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var ReactStyle = require('ReactStyle');
+
+var SiteBoilerPlateStyleRules = ReactStyle.create({
+  '*': {
+    boxSizing: 'border-box'
+  }
+});
+
+module.exports = SiteBoilerPlateStyleRules;

--- a/src/elements/Banner/Banner.js
+++ b/src/elements/Banner/Banner.js
@@ -18,7 +18,7 @@
 "use strict";
 
 var React = require('React');
-var BannerStyleRules = require('BannerStyleRules');
+var BannerStyleRules = require('./BannerStyleRules.js');
 var ReactStyle = require('ReactStyle');
 
 /**

--- a/src/elements/Banner/BannerStyleRules.js
+++ b/src/elements/Banner/BannerStyleRules.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2013 Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+"use strict";
+
+var ReactStyle = require('ReactStyle');
+
+var BannerStyleRules = ReactStyle.create({
+  'h1.banner': {
+    opacity: '0',
+    fontFamily: 'Helvetica',
+    color: '#444',
+    fontWeight: 'bold',
+    marginTop: '60px',
+    marginBottom: '0',
+    textAlign: 'center',
+    '-webkit-user-select': 'none',
+    fontSize: '5vh', /* Chrome bug prevents resizing on window resize! */
+    width: '100%'    /* Putting width 100% causes repaint on resize */
+  },
+  'h1.banner.fadeIn': {
+    opacity: '1',
+    transition: 'opacity 3s ease-in'
+  }
+});
+
+module.exports = BannerStyleRules;


### PR DESCRIPTION
a74367c deleted CSS files in favor of using react-styles to manage styling, but didn't add the necessary style modules or define them in packages.json. This fixes the "requiring unknown module" error, and reimplements the same visual style from before. Note: styles may not be applied correctly due to the use of Unicode in the react-styles namespacing, see https://github.com/hedgerwang/react-styles/pull/1
